### PR TITLE
feat: run ERA5 wind models from VM, sync to cloud storage 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "cdsapi>=0.7.4",
     "gcsfs",
     "zarr",
+    "paramiko",
 ]
 
 [project.urls]

--- a/run_wind_cutout.sh
+++ b/run_wind_cutout.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Ensure the script is called with the required arguments
+if [ "$#" -ne 6 ]; then
+    echo "Usage: $0 <lat1> <lon1> <lat2> <lon2> <start_date> <end_date>"
+    exit 1
+fi
+
+# Capture arguments
+LAT1=$1
+LON1=$2
+LAT2=$3
+LON2=$4
+START_DATE=$5
+END_DATE=$6
+
+# Navigate to the appropriate directory
+cd cd_atlite || { echo "Error: Could not change to directory 'cd_atlite'"; exit 1; }
+
+# Activate the virtual environment
+source venv/bin/activate || { echo "Error: Could not activate virtual environment"; exit 1; }
+
+# Run the Python script with the provided arguments
+python3 wind_cutout.py "$LAT1" "$LON1" "$LAT2" "$LON2" "$START_DATE" "$END_DATE" || {
+    echo "Error: Failed to run wind_cutout.py"
+    exit 1
+}
+
+# Print success message
+echo "Wind cutout process completed successfully."

--- a/wind_cf.py
+++ b/wind_cf.py
@@ -46,11 +46,11 @@ print(f"Max Longitude: {max_lon:.6f}")
 
 cutout = atlite.Cutout(
     # path="limon_co_wind.nc",
-    path="ne_wind_new.nc",
+    path="ne_wind_new_1day.nc",
     module="era5",
     x=slice(min_lon + 180, max_lon + 180),  # convert to 360 here, avoid differences between fetching & existing .nc paths
     y=slice(min_lat, max_lat),
-    time="2023-01",
+    time="2023-01-01",
     dt="h",
 )
 cutout.prepare(show_progress=True)

--- a/wind_cutout.py
+++ b/wind_cutout.py
@@ -1,0 +1,44 @@
+import atlite
+from math import cos, radians
+import logging
+import xarray as xr
+from datetime import datetime
+
+logging.basicConfig(level=logging.INFO)
+
+import sys
+
+# Check if the correct number of arguments are provided
+if len(sys.argv) != 8:
+    raise ValueError("Please provide exactly 7 arguments: lat1, lon1, lat2, lon2, startdate, enddate")
+
+# Assign command line arguments to variables
+lat1 = float(sys.argv[1])
+lon1 = float(sys.argv[2])
+lat2 = float(sys.argv[3])
+lon2 = float(sys.argv[4])
+startdate = sys.argv[5]
+enddate = sys.argv[6]
+
+# Calculate min and max latitudes and longitudes
+min_lat = min(lat1, lat2)
+max_lat = max(lat1, lat2)
+min_lon = min(lon1, lon2)
+max_lon = max(lon1, lon2)
+
+nc_filename = f"{lat1}_{lon1}_{lat2}_{lon2}_{startdate}_{enddate}.nc"
+
+cutout = atlite.Cutout(
+    path=nc_filename,
+    module="era5",
+    x=slice(min_lon + 180, max_lon + 180),  # convert to 360 here, avoid differences between fetching & existing .nc paths
+    y=slice(min_lat, max_lat),
+    time=slice(startdate, enddate),
+    dt="h",
+)
+cutout.prepare(show_progress=True)
+
+# Print out the current time
+current_time = datetime.now()
+print(f"Post prepare time: {current_time}")
+

--- a/wind_cutout.py
+++ b/wind_cutout.py
@@ -3,6 +3,7 @@ from math import cos, radians
 import logging
 import xarray as xr
 from datetime import datetime
+import subprocess
 
 logging.basicConfig(level=logging.INFO)
 
@@ -41,4 +42,22 @@ cutout.prepare(show_progress=True)
 # Print out the current time
 current_time = datetime.now()
 print(f"Post prepare time: {current_time}")
+
+# Construct the shell command
+gcloud_command = [
+    "gcloud", "storage", "cp", nc_filename, "gs://era5_wind_cutouts"
+]
+
+# Run the command
+try:
+    result = subprocess.run(gcloud_command, capture_output=True, text=True)
+    
+    # Check if the command was successful
+    if result.returncode == 0:
+        print("File successfully uploaded to Google Cloud Storage.")
+    else:
+        print(f"Error: {result.stderr}")
+except Exception as e:
+    print(f"An error occurred while uploading the file: {e}")
+
 

--- a/wind_vm.py
+++ b/wind_vm.py
@@ -1,0 +1,71 @@
+import paramiko
+from google.cloud import storage
+from google.cloud import storage
+from google.auth import default
+
+import sys
+import subprocess
+
+project = "inner-analyst-398816"
+instance_name = "ehren-era5-vm2"
+zone = "us-central1-c"
+
+def run_commands_on_vm(commands):
+    """
+    Runs a series of commands on a Google Cloud VM using gcloud SSH.
+    
+    Args:
+        project (str): Google Cloud project ID.
+        instance_name (str): Name of the VM instance.
+        zone (str): Zone of the VM instance.
+        commands (list): List of commands to execute sequentially on the VM.
+    """
+    try:
+        for command in commands:
+            # Construct the gcloud SSH command
+            gcloud_command = [
+                "gcloud", "compute", "ssh",
+                instance_name,
+                "--project", project,
+                "--zone", zone,
+                "--command", command
+            ]
+            
+            # Run the command
+            print(f"Running command on VM: {command}")
+            result = subprocess.run(gcloud_command, capture_output=True, text=True)
+            
+            # Print the output
+            if result.returncode == 0:
+                print(result.stdout)
+            else:
+                print(f"Error: {result.stderr}")
+                break
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+# Example Usage
+project = "inner-analyst-398816"
+instance_name = "ehren-era5-vm2"
+zone = "us-central1-c"
+
+def run_process_on_vm_and_transfer(lat1, lon1, lat2, lon2, start_date, end_date):
+    # Define commands to run on the VM
+    commands = [
+        f"./run_wind_cutout.sh {lat1} {lon1} {lat2} {lon2} {start_date} {end_date}"  # Placeholder for file creation (replace with real command)
+    ]
+    run_commands_on_vm(commands)
+
+# Check if the correct number of arguments are provided
+if len(sys.argv) != 7:
+    raise ValueError("Please provide exactly 6 arguments: lat1, lon1, lat2, lon2, startdate, enddate")
+
+# Assign command line arguments to variables
+lat1 = float(sys.argv[1])
+lon1 = float(sys.argv[2])
+lat2 = float(sys.argv[3])
+lon2 = float(sys.argv[4])
+startdate = sys.argv[5]
+enddate = sys.argv[6]
+
+run_process_on_vm_and_transfer(lat1, lon1, lat2, lon2, startdate, enddate)

--- a/wind_vm.py
+++ b/wind_vm.py
@@ -65,6 +65,8 @@ lat1 = float(sys.argv[1])
 lon1 = float(sys.argv[2])
 lat2 = float(sys.argv[3])
 lon2 = float(sys.argv[4])
+
+
 startdate = sys.argv[5]
 enddate = sys.argv[6]
 


### PR DESCRIPTION
This PR should help with the end to end process of creating wind power plant models from ERA5 weather data and atlite. This repo is a fork of atlite that fetches ERA5 weather data from a special public Google Cloud Storage bucket in uscentral1, instead of from the Climate Data Store / cdsapi. I've been running it on a VM in uscentral1, and it finishes annual data fetches for a single location in about ~10 minutes. This PR then pushes the .nc (cutout) file to a cloud storage bucket, where Svante can do the final step depending on the user's turbine & other preferences. 

Important pieces: 
* wind_cutout.py - a cleaned up version of wind_cf.py with command line arguments for a lat/lon and date bounding box. Typical usage should be a tiny 0.25 degree box and startdate/enddate defining a calendar year. 
* run_wind_cutout.sh - a shell script designed to be run from a developer/analyst's local machine, which kicks off a couple commands and runs wind_cutout.py, as well as copying the resulting .nc file to Google Cloud Storage. 

Testing
* This runs successfully from my local machine (--> VM) most of the time, in about 10 minutes. That's good enough for our needs at the moment. 